### PR TITLE
Support Android down to SDK 14

### DIFF
--- a/PcscLike/build.gradle
+++ b/PcscLike/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'org.jetbrains.dokka-android'
 android {
     compileSdkVersion 28
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 14
         targetSdkVersion 28
         versionCode = (getRevisionMajor() + getRevisionMinor()).toInteger()
         versionName getRevision()

--- a/PcscLike/src/main/java/com/springcard/pcsclike/BluetoothLayer.kt
+++ b/PcscLike/src/main/java/com/springcard/pcsclike/BluetoothLayer.kt
@@ -8,11 +8,14 @@ package com.springcard.pcsclike
 
 import android.bluetooth.*
 import android.content.Context
+import android.os.Build
+import android.support.annotation.RequiresApi
 import android.util.Log
 import java.util.*
 import kotlin.experimental.and
 
 
+@RequiresApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
 internal class BluetoothLayer(private var bluetoothDevice: BluetoothDevice, private var callbacks: SCardReaderListCallback, private var scardReaderList : SCardReaderList): CommunicationLayer(callbacks, scardReaderList) {
 
     private val TAG = this::class.java.simpleName
@@ -95,6 +98,12 @@ internal class BluetoothLayer(private var bluetoothDevice: BluetoothDevice, priv
         }
     }
 
+    init {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2) {
+            // Fail fast in case somebody ignored the @RequiresApi annotation
+            throw UnsupportedOperationException("BLE not available on Android SDK < ${Build.VERSION_CODES.JELLY_BEAN_MR2}")
+        }
+    }
 
     /* Utilities methods */
 

--- a/PcscLike/src/main/java/com/springcard/pcsclike/SCardReaderListBle.kt
+++ b/PcscLike/src/main/java/com/springcard/pcsclike/SCardReaderListBle.kt
@@ -8,8 +8,11 @@ package com.springcard.pcsclike
 
 import android.bluetooth.BluetoothDevice
 import android.content.Context
+import android.os.Build
+import android.support.annotation.RequiresApi
 
 
+@RequiresApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
 class SCardReaderListBle internal constructor(layerDevice: BluetoothDevice, callbacks: SCardReaderListCallback): SCardReaderList(layerDevice as Any, callbacks) {
 
     private fun create(ctx : Context) {

--- a/PcscLike/src/main/java/com/springcard/pcsclike/UsbLayer.kt
+++ b/PcscLike/src/main/java/com/springcard/pcsclike/UsbLayer.kt
@@ -14,8 +14,10 @@ import android.hardware.usb.*
 import android.util.Log
 import java.nio.ByteBuffer
 import android.hardware.usb.UsbRequest
+import android.os.Build
 import android.os.Handler
 import android.os.HandlerThread
+import android.hardware.usb.UsbConstants
 
 
 internal class UsbLayer(private var usbDevice: UsbDevice, private var callbacks: SCardReaderListCallback, private var scardReaderList : SCardReaderList): CommunicationLayer(callbacks, scardReaderList) {
@@ -90,12 +92,6 @@ internal class UsbLayer(private var usbDevice: UsbDevice, private var callbacks:
 
                 if (connect()) {
                     currentState = State.ReadingInformation
-
-                    /* Get info directly from USB */
-                    scardReaderList.vendorName = usbDevice.manufacturerName ?: ""
-                    scardReaderList.productName = usbDevice.productName ?: ""
-                    scardReaderList.serialNumber = usbDevice.serialNumber ?: ""
-                    scardReaderList.serialNumberRaw = (usbDevice.serialNumber ?: "").hexStringToByteArray()
 
                     /* Trigger 1st APDU to get 1st info */
                     indexInfoCmd = 1 // 1st command
@@ -416,10 +412,43 @@ internal class UsbLayer(private var usbDevice: UsbDevice, private var callbacks:
             curPos += dlen
         }
 
+        /* Get info directly from USB */
+        val manufacturerName: String
+        val productName: String
+        val serialNumber: String
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            manufacturerName = usbDevice.manufacturerName ?: ""
+            productName = usbDevice.productName ?: ""
+            serialNumber = usbDevice.serialNumber ?: ""
+        } else {
+            val buffer = ByteArray(255)
+            manufacturerName = usbDeviceConnection.getString(descriptor, 14 /* iManufacturer */, buffer)
+            productName = usbDeviceConnection.getString(descriptor, 15 /* iProduct */, buffer)
+            serialNumber = usbDeviceConnection.getString(descriptor, 16 /* iSerialNumber */, buffer)
+        }
+        scardReaderList.vendorName = manufacturerName
+        scardReaderList.productName = productName
+        scardReaderList.serialNumber = serialNumber
+        scardReaderList.serialNumberRaw = serialNumber.hexStringToByteArray()
+
         return  scardReaderList.slotCount != 0
     }
 
+    private fun UsbDeviceConnection.getString(rawDescriptor: ByteArray, index: Int, buffer: ByteArray): String {
+        val len = controlTransfer(
+            UsbConstants.USB_DIR_IN or UsbConstants.USB_TYPE_STANDARD,
+            0x06 /* GET_DESCRIPTOR */,
+            (0x03 /* DESCRIPTOR_STRING */ shl 8) or rawDescriptor[index].toInt(),
+            0, buffer, buffer.size,
+            0
+        )
+        if (len < 0) {
+            // Read failure
+            return ""
+        }
 
+        return String(buffer, 2, len - 2, Charsets.UTF_16LE)
+    }
 
     private fun stop() {
         synchronized(mWaiterThread) {


### PR DESCRIPTION
Here are some changes to allow using your library on Android before Lollipop.

This back-port enable using:
- USB communication on Android down to Ice Cream Sandwich SDK 14
- Bluetooth communication on Android down to Jellybean SDK 18
  - (before API 18 a Lint warning will pop thanks to an `@RequiresApi` annotation, and an exception will be thrown from the constructor of the `BluetoothLayer` class)
